### PR TITLE
For a 0.1.2 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NearestNeighborModels"
 uuid = "636a865e-7cf4-491e-846c-de09b730eb36"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Sebastian Vollmer <s.vollmer.4@warwick.ac.uk>", "Thibaut Lienart <thibaut.lienart@gmail.com>", "Okon Samuel <okonsamuel50@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"


### PR DESCRIPTION
Something funny is going on. Current master does no match the tagged version 0.1.1. In the tagged version we still have `PKG=NearestNeighoborsModels` instead of `PKG=NearestNeighoborModels`. 

Going to try tagging a new release and hopefully that fixes it. 

