### PR TITLE
Alternative fix for #31

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Distances = "^0.9,^0.10"
-FillArrays = "^0.9"
+Distances = "^0.9, ^0.10"
+FillArrays = "^0.9, ^0.10, ^0.11 "
 MLJModelInterface = "^0.3.5, ^0.4"
 NearestNeighbors = "^0.4"
 StatsBase = "^0.33"

--- a/src/models.jl
+++ b/src/models.jl
@@ -234,6 +234,7 @@ function _predict_knnreg(weights, y, idxs_matrix)
     )
     return preds
 end
+
 function MMI.predict(m::KNNRegressor, fitresult, X)
     err_if_given_invalid_K(m.K)
     #Xmatrix = MMI.matrix(X, transpose=true) # NOTE: copies the data

--- a/src/models.jl
+++ b/src/models.jl
@@ -229,7 +229,9 @@ end
 
 function _predict_knnreg(weights, y, idxs_matrix)
     @inbounds labels = @view(y[idxs_matrix])
-    preds = @view(_sum(labels .* weights, dims=2)[:]) ./ _sum(weights, dims=2)
+    preds = @inbounds(
+        @view(_sum(labels .* weights, dims=2)[:]) ./ @view(_sum(weights, dims=2)[:])
+    )
     return preds
 end
 function MMI.predict(m::KNNRegressor, fitresult, X)
@@ -238,7 +240,7 @@ function MMI.predict(m::KNNRegressor, fitresult, X)
     Xmatrix = transpose(MMI.matrix(X))
     check_onebased_indexing("prediction input", Xmatrix)
     predict_args = setup_predict_args(m, Xmatrix, fitresult)
-    preds = _predict_knnreg(predict_args...) |> vec
+    preds = _predict_knnreg(predict_args...)
     return preds
 end
 


### PR DESCRIPTION
This gives an alternative fix to #31 with less allocations. Also the compat entry for `FillArrays` has been updated from `"^0.9"` to `"^0.9, ^0.10, ^0.11 "` 