### PR TITLE
replace DictTable with DictColumnTable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NearestNeighborModels"
 uuid = "636a865e-7cf4-491e-846c-de09b730eb36"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Sebastian Vollmer <s.vollmer.4@warwick.ac.uk>", "Thibaut Lienart <thibaut.lienart@gmail.com>", "Okon Samuel <okonsamuel50@gmail.com>"]
-version = "0.2.3"
+version = "0.2.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -13,15 +13,17 @@ NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
 Distances = "^0.9, ^0.10"
-FillArrays = "^0.9, ^0.10, ^0.11, 0.12, 0.13, 1.0"
+FillArrays = "^0.9, ^0.10, ^0.11, 0.12, 0.13, 1"
 MLJModelInterface = "1.4"
 NearestNeighbors = "^0.4"
-StatsBase = "0.33, 0.34"
+OrderedCollections = "1.1"
+StatsBase = "^0.33, 0.34"
 Tables = "^1.2"
-julia = "1.6"
+julia = "1.3"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/src/NearestNeighborModels.jl
+++ b/src/NearestNeighborModels.jl
@@ -14,6 +14,7 @@ using Distances
 using FillArrays
 using LinearAlgebra
 using Statistics
+using OrderedCollections
 
 # ==============================================================================================
 ## EXPORTS
@@ -36,8 +37,8 @@ const Vec{T} = AbstractVector{T}
 const Mat{T} = AbstractMatrix{T}
 const Arr{T, N} = AbstractArray{T, N}
 const ColumnTable =  Tables.ColumnTable
-const DictTable = Tables.DictColumns
-const MultiUnivariateFinite = Union{DictTable, ColumnTable}
+const DictColumnTable = Tables.DictColumnTable
+const MultiUnivariateFinite = Union{DictColumnTable, ColumnTable}
 
 # Define constants for easy referencing of packages
 const MMI = MLJModelInterface


### PR DESCRIPTION
`DictTable` are just the julia `Dict`s which doesn't preserve ordering. 
This PR replaces `DictTable` with `DictColumnTable` which preseve key ordering.